### PR TITLE
Change duration and playhead unit from seconds to milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 All notable changes to this project will be documented in this file.
 
+## [0.11.1] - 2021/01/19
+### Fix
+- Change `getDuration` unit from seconds to milliseconds
+- Change `getPlayhead` unit from seconds to milliseconds
+
 ## [0.11.0] - 2020/10/02
 ### Update
 - Core dependencies.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic-video-jwplayer",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "New relic tracker for jwplayer",
   "main": "src/index.js",
   "scripts": {

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -23,11 +23,11 @@ export default class JwplayerTracker extends nrvideo.VideoTracker {
   }
 
   getPlayhead () {
-    return this.player.getPosition()
+    return this.player.getPosition() * 1000;
   }
 
   getDuration () {
-    return this.player.getDuration()
+    return this.player.getDuration() * 1000;
   }
 
   getRenditionBitrate () {


### PR DESCRIPTION
## ⚠️ Problem

iOS/Android trackers report duration and playhead in _ms_ and this tracker reports it in _s_.

## 🔨  Solution

To ensure constancy, we make sure to report in _ms_ in the JS tracker as well.